### PR TITLE
Return normal response with updated context

### DIFF
--- a/defender/decorators.py
+++ b/defender/decorators.py
@@ -47,7 +47,7 @@ def watch_login(func):
                 return utils.lockout_response(request)
 
             elif login_attempt_status == config.LoginAttemptStatus.LOGIN_FAILED_SHOW_WARNING:
-                response.context["defender_number_of_attempts"] = utils.get_user_attempts(request)
+                response.context["defender_attempts_left"] = config.FAILURE_LIMIT - utils.get_user_attempts(request)
                 return response
 
         return response

--- a/defender/decorators.py
+++ b/defender/decorators.py
@@ -47,11 +47,8 @@ def watch_login(func):
                 return utils.lockout_response(request)
 
             elif login_attempt_status == config.LoginAttemptStatus.LOGIN_FAILED_SHOW_WARNING:
-                number_of_attempts = utils.get_user_attempts(request)
-                return render_to_response('auth/login.html', {"error_list": ["Invalid email and/or password. "
-                                                                             "WARNING: Your account will lock after {0} "
-                                                                             "more unsuccessful login attempts.".format(config.FAILURE_LIMIT - number_of_attempts)]},
-                                                                             context_instance=RequestContext(request))
+                response.context["defender_number_of_attempts"] = utils.get_user_attempts(request)
+                return response
 
         return response
 


### PR DESCRIPTION
Instead of hard-coding error messaging and path to the login template, just update the context with a flag indicating how many attempts are left.
